### PR TITLE
Make API more usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/bin.js
+++ b/bin.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const mkvSubtitleExtractor = require('.')
+const z = require('zero-fill')
 
 if (process.argv.length < 3 || process.argv[2] === '--help') {
   const pkg = require('./package.json')
@@ -12,4 +13,20 @@ if (process.argv.length < 3 || process.argv[2] === '--help') {
 
 const mkvPaths = process.argv.slice(2)
 
-mkvPaths.forEach(path => mkvSubtitleExtractor(path))
+console.log('Processing ' + mkvPaths.join(' & '))
+
+let promise = Promise.resolve()
+
+mkvPaths.forEach(path => {
+  promise = promise.then(() => mkvSubtitleExtractor(path)
+    .then(tracks => {
+      console.log(path)
+      if (tracks.size === 0) return console.log('    No subtitle tracks found.')
+      tracks.forEach(track => console.log(`    Track ${z(2, track.number)} → ${track.path}`))
+    })
+    .catch(err => {
+      console.error(`Error while processing ${path}:`, err.message)
+      process.exit(1)
+    })
+  )
+})

--- a/bin.js
+++ b/bin.js
@@ -13,8 +13,6 @@ if (process.argv.length < 3 || process.argv[2] === '--help') {
 
 const mkvPaths = process.argv.slice(2)
 
-console.log('Processing ' + mkvPaths.join(' & '))
-
 let promise = Promise.resolve()
 
 mkvPaths.forEach(path => {

--- a/bin.js
+++ b/bin.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
+'use strict'
+
 const mkvSubtitleExtractor = require('.')
 
 if (process.argv.length < 3 || process.argv[2] === '--help') {
-  var pkg = require('./package.json')
+  const pkg = require('./package.json')
   console.log(`Version ${pkg.version}`)
   console.log(`Usage: ${pkg.name} <file.mkv ...>`)
   process.exit(0)
 }
 
-var mkvPaths = process.argv.slice(2)
+const mkvPaths = process.argv.slice(2)
 
 mkvPaths.forEach(path => mkvSubtitleExtractor(path))

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const matroskaSubtitles = require('matroska-subtitles')
 /**
  * Reads mkv file and writes srt files in same location
  */
-module.exports = function (mkvPath) {
+module.exports = function (mkvPath, outputDir) {
   const file = fs.createReadStream(mkvPath)
 
   file.on('error', function (err) {
@@ -15,7 +15,7 @@ module.exports = function (mkvPath) {
     process.exit(1)
   })
 
-  const dir = path.dirname(mkvPath)
+  const dir = outputDir || path.dirname(mkvPath)
   const name = path.basename(mkvPath, path.extname(mkvPath))
 
   // create srt path from language suffix

--- a/index.js
+++ b/index.js
@@ -8,33 +8,33 @@ const matroskaSubtitles = require('matroska-subtitles')
  * Reads mkv file and writes srt files in same location
  */
 module.exports = function (mkvPath) {
-  var file = fs.createReadStream(mkvPath)
+  const file = fs.createReadStream(mkvPath)
 
   file.on('error', function (err) {
     console.error('Error:', err.message)
     process.exit(1)
   })
 
-  var dir = path.dirname(mkvPath)
-  var name = path.basename(mkvPath, path.extname(mkvPath))
+  const dir = path.dirname(mkvPath)
+  const name = path.basename(mkvPath, path.extname(mkvPath))
 
   // create srt path from language suffix
-  var srtPath = function (language) {
-    var languageSuffix = language ? '.' + language : ''
+  const srtPath = function (language) {
+    const languageSuffix = language ? '.' + language : ''
     return path.join(dir, name + languageSuffix + '.srt')
   }
 
-  var tracks = new Map()
-  var subs = matroskaSubtitles()
+  const tracks = new Map()
+  const subs = matroskaSubtitles()
 
   subs.on('data', function (data) {
     if (data[0] === 'new') {
       // sometimes `und` (undefined) is used as the default value, instead of leaving the tag unassigned
-      var language = data[1].language !== 'und' ? data[1].language : null
-      var subtitlePath = srtPath(language)
+      const language = data[1].language !== 'und' ? data[1].language : null
+      let subtitlePath = srtPath(language)
 
       // obtain unique filename (don't overwrite)
-      for (var i = 2; fileExists(subtitlePath); i++) {
+      for (let i = 2; fileExists(subtitlePath); i++) {
         subtitlePath = language ? srtPath(language + i) : srtPath(i)
       }
 
@@ -43,8 +43,8 @@ module.exports = function (mkvPath) {
         file: fs.createWriteStream(subtitlePath)
       })
     } else {
-      var track = tracks.get(data[0])
-      var sub = data[1]
+      const track = tracks.get(data[0])
+      const sub = data[1]
 
       // convert to srt format
       track.file.write(`${track.index++}\r\n`)
@@ -71,12 +71,12 @@ module.exports = function (mkvPath) {
 
 // https://stackoverflow.com/questions/9763441/milliseconds-to-time-in-javascript
 function msToTime (s) {
-  var ms = s % 1000
+  const ms = s % 1000
   s = (s - ms) / 1000
-  var secs = s % 60
+  const secs = s % 60
   s = (s - secs) / 60
-  var mins = s % 60
-  var hrs = (s - mins) / 60
+  const mins = s % 60
+  const hrs = (s - mins) / 60
 
   return z(2, hrs) + ':' + z(2, mins) + ':' + z(2, secs) + ',' + z(3, ms)
 }

--- a/index.js
+++ b/index.js
@@ -3,73 +3,8 @@
 const fs = require('fs')
 const path = require('path')
 const z = require('zero-fill')
-const fileExists = require('file-exists')
-const matroskaSubtitles = require('matroska-subtitles')
-
-/**
- * Reads mkv file and writes srt files in same location
- */
-module.exports = function (mkvPath, outputDir) {
-  const file = fs.createReadStream(mkvPath)
-
-  file.on('error', function (err) {
-    console.error('Error:', err.message)
-    process.exit(1)
-  })
-
-  const dir = outputDir || path.dirname(mkvPath)
-  const name = path.basename(mkvPath, path.extname(mkvPath))
-
-  // create srt path from language suffix
-  const srtPath = function (language) {
-    const languageSuffix = language ? '.' + language : ''
-    return path.join(dir, name + languageSuffix + '.srt')
-  }
-
-  const tracks = new Map()
-  const subs = matroskaSubtitles()
-
-  subs.on('data', function (data) {
-    if (data[0] === 'new') {
-      // sometimes `und` (undefined) is used as the default value, instead of leaving the tag unassigned
-      const language = data[1].language !== 'und' ? data[1].language : null
-      let subtitlePath = srtPath(language)
-
-      // obtain unique filename (don't overwrite)
-      for (let i = 2; fileExists(subtitlePath); i++) {
-        subtitlePath = language ? srtPath(language + i) : srtPath(i)
-      }
-
-      tracks.set(data[1].track, {
-        index: 1,
-        file: fs.createWriteStream(subtitlePath)
-      })
-    } else {
-      const track = tracks.get(data[0])
-      const sub = data[1]
-
-      // convert to srt format
-      track.file.write(`${track.index++}\r\n`)
-      track.file.write(`${msToTime(sub.time)} --> ${msToTime(sub.time + sub.duration)}\r\n`)
-      track.file.write(`${sub.text}\r\n\r\n`)
-    }
-  })
-
-  subs.on('end', function () {
-    console.log(mkvPath)
-
-    if (tracks.size === 0) {
-      return console.log('    No subtitle tracks found.')
-    }
-
-    tracks.forEach(function (track, i) {
-      track.file.end()
-      console.log(`    Track ${z(2, i)} → ${track.file.path}`)
-    })
-  })
-
-  file.pipe(subs)
-}
+const fileExists = require('file-exists').sync
+const MatroskaSubtitles = require('matroska-subtitles')
 
 // https://stackoverflow.com/questions/9763441/milliseconds-to-time-in-javascript
 function msToTime (s) {
@@ -82,3 +17,64 @@ function msToTime (s) {
 
   return z(2, hrs) + ':' + z(2, mins) + ':' + z(2, secs) + ',' + z(3, ms)
 }
+
+/**
+ * Reads mkv file and writes srt files in same location or in outputDir
+ */
+const mkvSubtitleExtractor = (mkvPath, outputDir) => new Promise((resolve, reject) => {
+  const dir = outputDir || path.dirname(mkvPath)
+  const name = path.basename(mkvPath, path.extname(mkvPath))
+
+  // create srt path from language suffix
+  const srtPath = function (language) {
+    const languageSuffix = language ? '.' + language : ''
+    return path.join(dir, name + languageSuffix + '.srt')
+  }
+
+  const tracks = new Map()
+  const subs = new MatroskaSubtitles()
+
+  subs.once('tracks', tracks_ => {
+    tracks_.forEach(track => {
+      // sometimes `und` (undefined) is used as the default value, instead of leaving the tag unassigned
+      const language = track.language !== 'und' ? track.language : null
+      let subtitlePath = srtPath(language)
+
+      // obtain unique filename (don't overwrite)
+      for (let i = 2; fileExists(subtitlePath); i++) {
+        subtitlePath = language ? srtPath(language + i) : srtPath(i)
+      }
+
+      tracks.set(track.number, {
+        index: 1,
+        file: fs.createWriteStream(subtitlePath),
+        language
+      })
+    })
+  })
+
+  subs.on('subtitle', (sub, trackNumber) => {
+    const track = tracks.get(trackNumber)
+
+    // convert to srt format
+    track.file.write(`${track.index++}\r\n`)
+    track.file.write(`${msToTime(sub.time)} --> ${msToTime(sub.time + sub.duration)}\r\n`)
+    track.file.write(`${sub.text}\r\n\r\n`)
+  })
+
+  subs.on('finish', () => {
+    const tracks_ = []
+
+    tracks.forEach((track, i) => {
+      track.file.end()
+      tracks_.push({number: i, path: track.file.path, language: track.language})
+    })
+    resolve(tracks_)
+  })
+
+  const file = fs.createReadStream(mkvPath)
+  file.on('error', err => reject(err))
+  file.pipe(subs)
+})
+
+module.exports = mkvSubtitleExtractor

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('fs')
 const path = require('path')
 const z = require('zero-fill')

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "author": "Mathias Rasmussen <mathiasvr@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "file-exists": "^1.0.0",
-    "matroska-subtitles": "^1.0.1",
+    "file-exists": "^4.0.0",
+    "matroska-subtitles": "^2.0.1",
     "zero-fill": "^2.2.3"
   },
   "devDependencies": {},


### PR DESCRIPTION
Hello,

Thanks for your amazing work!
I've used this tool for a small project of mine. However, the library version of it was not very usable as such: it used `process.exit` directly, there was no way of knowing when it was done, no way of specifying where to output the files ... So I made these few small changes, and along the way took this opportunity to clean up the code a bit and bump the dependencies :)

I would love to see this merged so others can use this module as a library!